### PR TITLE
Enable file ext and optional seq key in templates

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -50,18 +50,18 @@ configuration:
                     type: tank_type
                 render_template:
                     type: template
-                    fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], [YYYY], [MM], [DD], *
+                    fields: context, version, [SEQ], [channel], [output], [name], [width], [height], [eye], [YYYY], [MM], [DD], *
                 publish_template:
                     type: template
-                    fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], [TankType], *
+                    fields: context, version, [SEQ], [channel], [output], [name], [width], [height], [eye], [TankType], *
                 proxy_render_template:
                     type: template
-                    fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], *
+                    fields: context, version, [SEQ], [channel], [output], [name], [width], [height], [eye], *
                     allows_empty: True
                     default_value: null
                 proxy_publish_template:
                     type: template
-                    fields: context, version, SEQ, [channel], [output], [name], [width], [height], [eye], [TankType], *
+                    fields: context, version, [SEQ], [channel], [output], [name], [width], [height], [eye], [TankType], *
                     allows_empty: True
                     default_value: null
                 tile_color:

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1735,8 +1735,17 @@ class TankWriteNodeHandler(object):
         anything other than a format (e.g. scale, box)!
         """
         if not nuke.exists("root"):
-            return
+            return 0, 0
         root = nuke.root()
+        # Sometimes on scene setup the root node is existed but not accessible yet.
+        # So we try to find a knob on it and if that throws an error we return (0,0)
+        # This is ok since width and height get correctly calculated later.
+        try:
+            "proxy_type" not in root.knobs()
+        except ValueError as err:
+            if str(err) == 'A PythonObject is not attached to a node':
+                return 0, 0
+            raise
 
         # calculate scale and offset to apply for proxy
         scale_x = scale_y = 1.0

--- a/python/tk_nuke_writenode/handler.py
+++ b/python/tk_nuke_writenode/handler.py
@@ -1833,6 +1833,17 @@ class TankWriteNodeHandler(object):
             node, render_template, width, height, output_name
         )
 
+    def __get_file_extension_from_node(self, node):
+        """
+        :returns: The file extension that the current node uses.
+        :rtype: str
+        """
+        settings = self.__get_node_profile_settings(node)
+        raw_file_ext = settings['file_type'].lower()
+        # Return the short forms of file extensions where possible.
+        return {'jpeg': 'jpg',
+                'tiff': 'tif'}.get(raw_file_ext, raw_file_ext)
+
     def __compute_render_path_from(
         self, node, render_template, width, height, output_name
     ):
@@ -1870,6 +1881,9 @@ class TankWriteNodeHandler(object):
 
         # Force use of %d format for nuke renders:
         fields["SEQ"] = "FORMAT: %d"
+
+        # Get the file extension from the node:
+        fields["extension"] = self.__get_file_extension_from_node(node)
 
         # use %V - full view printout as default for the eye field
         fields["eye"] = "%V"


### PR DESCRIPTION
This PR enables the use of a "extension" key in templates and also makes the "SEQ" key optional. This enables 2 things:

1. You can use the same template for different output formats. eg. "image.{extension}" works for exr and dpx write node configurations.
2. Making the "SEQ" key optional allows rendering to "mov"s.

This also includes a small bugfix that you can encounter when using proxy templates.